### PR TITLE
Support format option

### DIFF
--- a/lib/guard/rails_best_practices.rb
+++ b/lib/guard/rails_best_practices.rb
@@ -54,6 +54,8 @@ module Guard
       cmd += ' --spec'     if options[:spec]
       cmd += ' --test'     if options[:test]
       cmd += ' --features' if options[:features]
+      cmd += ' --output-file ' + options[:output_file] if options[:output_file]
+      cmd += ' --format ' + options[:format]           if options[:format]
       cmd += " --exclude #{options[:exclude]}" unless options[:exclude].blank?
       @result = system(cmd)
 


### PR DESCRIPTION
As watching guard output can get difficult with multiple guards active at the same time, all of them spaming output with 30+ lines, it is good idea to support format option, outputing results to html.

This is by no means THE way to do it, just a quick edit via github, since Issues are not enabled on this project.
